### PR TITLE
Fix input name mismatch and header handling

### DIFF
--- a/src/sccmecextractor/extract_SCCmec.py
+++ b/src/sccmecextractor/extract_SCCmec.py
@@ -159,6 +159,10 @@ class AttSiteCollection:
             for line in tsv:
                 columns = line.strip().split("\t")
                 input_file = columns[0]
+
+                # Skip duplicate header lines (from batch runs)
+                if input_file == "Input_File":
+                    continue
                 
                 # Only process entries for our target file
                 if input_file == self.target_file:
@@ -257,9 +261,7 @@ class SCCmecExtractor:
     
     def _get_input_filename(self, fna_path: str) -> str:
         """Extract the base filename without extension from the input path."""
-        base = os.path.basename(fna_path)
-        base_full = os.path.splitext(base)[0]
-        return base_full.split(".")[0]
+        return Path(fna_path).stem
     
     def _determine_extraction_coordinates(self, rlmH_start: int, att_right: AttSite, att_left: AttSite) -> Tuple[int, int, bool]:
         """Determine the coordinates for SCCmec extraction."""

--- a/src/sccmecextractor/locate_att_sites.py
+++ b/src/sccmecextractor/locate_att_sites.py
@@ -206,10 +206,14 @@ class AttSiteFinder:
     def write_results(self, sites: List[AttSite], output_file: str):
         """Write results to TSV file."""
         input_file_name = Path(self.fasta_file).stem
-        
+
+        output_path = Path(output_file)
+        write_header = not output_path.exists() or output_path.stat().st_size == 0
+
         with open(output_file, 'a') as f:
-            f.write("Input_File\tPattern\tContig\tStart\tEnd\tMatching_Sequence\n")
-            
+            if write_header:
+                f.write("Input_File\tPattern\tContig\tStart\tEnd\tMatching_Sequence\n")
+
             for site in sites:
                 f.write(site.to_tsv_line(input_file_name) + "\n")
 


### PR DESCRIPTION
Had noticed input name processing was inconsistent between locate_att_sites and extract_sccmec, making extract_sccmec fail even with valid input.